### PR TITLE
Fix networking in Obj-C template

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ You can then delete the `MoveToNonUITestTarget` from the filesystem as the test 
 
 - Close the project window in Xcode.
 
-- On the command line, run `bundle install`. This will ensure that the necessary gems are installed for the build and test scripts that run on Travis, so that you can run them locally later on if needed. It will also generate `Gemfile.lock`, which should be committed so that the same versions of those gems will be installed on Travis. If this command fails, check that you have [RubyGems](https://rubygems.org/pages/download) and [Bundler](http://bundler.io/) installed.
+- On the command line, run `bundle install`. This will ensure that the correct version of CocoaPods is installed, along with the necessary gems for the build and test scripts that run on Travis, so that you can run them locally later on if needed. It will also generate `Gemfile.lock`, which should be committed so that the same versions of those gems will be installed on Travis. If this command fails, check that you have [RubyGems](https://rubygems.org/pages/download) and [Bundler](http://bundler.io/) installed.
 
-- On the command line, run `pod install`. Be sure to launch the project from the newly-created `.xcworkspace` file.  NOTE: cocoapods ~> 1.0 is required.
+- On the command line, run `bundle exec pod install`. Be sure to launch the project from the newly-created `.xcworkspace` file.
 
 ### 4. For Swift Only
 

--- a/Vokal-ObjC.xctemplate/TemplateInfo.plist
+++ b/Vokal-ObjC.xctemplate/TemplateInfo.plist
@@ -218,7 +218,7 @@
 					<key>Definitions</key>
 					<dict>
 						<key>../Podfile:afpod</key>
-						<string>    pod &apos;AFNetworking&apos;</string>
+						<string>    pod &apos;AFNetworking&apos;, &apos;~> 3.1&apos;</string>
 					</dict>
 					<key>Nodes</key>
 					<array>

--- a/Vokal-ObjC.xctemplate/___VARIABLE_classPrefix___HTTPSessionManager.m
+++ b/Vokal-ObjC.xctemplate/___VARIABLE_classPrefix___HTTPSessionManager.m
@@ -94,9 +94,13 @@ static ___VARIABLE_classPrefix___HTTPSessionManager *_sharedManager;
 
 // Override the data task completion handler to add debug logging
 - (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
-                            completionHandler:(void (^)(NSURLResponse *, id, NSError *))completionHandler
+                               uploadProgress:(void (^)(NSProgress * _Nonnull))uploadProgressBlock
+                             downloadProgress:(void (^)(NSProgress * _Nonnull))downloadProgressBlock
+                            completionHandler:(void (^)(NSURLResponse * _Nonnull, id _Nullable, NSError * _Nullable))completionHandler
 {
     return [super dataTaskWithRequest:request
+                       uploadProgress:uploadProgressBlock
+                     downloadProgress:downloadProgressBlock
                     completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
 #ifdef USE_NETWORKING_DEBUG_LOGGING
                         // Debug logging


### PR DESCRIPTION
The debug logging override wasn't working with the latest AFNetworking. Added a version to the Podfile to ensure the correct one is used. Also updated the README.

@vokal/ios-developers quick review please?
