### PR TITLE
Fix paths in the DevsJustWantToHaveFun script

### DIFF
--- a/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/DevsJustWantToHaveFun.sh
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/DevsJustWantToHaveFun.sh
@@ -15,13 +15,9 @@ fi
 # Resources path
 RESOURCES_DIR="${PROJECT_DIR}/___PACKAGENAME___/Resources"
 
-echo "Resources dir: ${RESOURCES_DIR}"
-
 # Path where the TrueColors file you want to use to generate
 # classes is located. Must include the .truecolors extension. 
 TRUECOLORS_PATH="${RESOURCES_DIR}/___PACKAGENAME___.truecolors"
-
-echo "TRUECOLORS_PATH: ${TRUECOLORS_PATH}"
 
 # Path where files should be output.
 OUTPUT_DIR="${RESOURCES_DIR}/TrueColors"

--- a/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/DevsJustWantToHaveFun.sh
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/DevsJustWantToHaveFun.sh
@@ -12,15 +12,22 @@ if [ -z "${PROJECT_NAME}" ]; then
     PROJECT_NAME="___PACKAGENAME___"
 fi
 
-# Path relative to this script where the TrueColors file you want to use to generate
+# Resources path
+RESOURCES_DIR="${PROJECT_DIR}/___PACKAGENAME___/Resources"
+
+echo "Resources dir: ${RESOURCES_DIR}"
+
+# Path where the TrueColors file you want to use to generate
 # classes is located. Must include the .truecolors extension. 
-TRUECOLORS_PATH="../Resources/___PACKAGENAME___.truecolors"
+TRUECOLORS_PATH="${RESOURCES_DIR}/___PACKAGENAME___.truecolors"
 
-# Path relative to this script where files should be output.
-OUTPUT_DIR="../Resources/TrueColors"
+echo "TRUECOLORS_PATH: ${TRUECOLORS_PATH}"
 
-# Path relative to this script where fonts should be placed 
-FONT_DIR="../Resources/Fonts"
+# Path where files should be output.
+OUTPUT_DIR="${RESOURCES_DIR}/TrueColors"
+
+# Path where fonts should be placed
+FONT_DIR="${RESOURCES_DIR}/Fonts"
 
 # Prefix to use for extensions/categories, ex: VOK. 
 PREFIX="FIXME"
@@ -40,4 +47,3 @@ fi
     --font-dir "${FONT_DIR}" \
     --prefix "${PREFIX}" \
     --"${LANGUAGE}"
-


### PR DESCRIPTION
I was getting a weird error:

> The folder “UIColor+TrueColors.swift” doesn’t exist.

I'm not sure where it was trying to use which path, but either way: updating it to use absolute paths fixed the problem (I borrowed this change from a client project that's been working all along).

@vokal/ios-developers and particularly @vokal-isaac, look OK?