### PR TITLE
Generic API closures

### DIFF
--- a/Vokal-Swift.xctemplate/APICompletionTests.swift
+++ b/Vokal-Swift.xctemplate/APICompletionTests.swift
@@ -131,8 +131,8 @@ class APICompletionTests: XCTestCase {
                                                 //THEN: the result data type is null as expected
                                                 expectation.fulfill()
         }, failure: { error in
-                XCTFail("API request failed. Error: \(error)")
-                expectation.fulfill()
+            XCTFail("API request failed. Error: \(error)")
+            expectation.fulfill()
         })
         
         self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)

--- a/Vokal-Swift.xctemplate/APICompletionTests.swift
+++ b/Vokal-Swift.xctemplate/APICompletionTests.swift
@@ -1,0 +1,106 @@
+//
+//  ___FILENAME___
+//  ___PACKAGENAME___
+//
+//  Created by ___FULLUSERNAME___ on ___DATE___.
+//___COPYRIGHT___
+//
+
+import XCTest
+@testable import ___PACKAGENAME___
+
+class APICompletionTests: XCTestCase {
+    
+    let StandardTestTimeout = 3.0
+    
+    //MARK: - Test Lifecycle
+    
+    override static func setUp() {
+        super.setUp()
+
+        //Use mock protocol
+        HTTPSessionManager.useMockData()
+    }
+
+    override static func tearDown() {
+        //Stop using mock protocol
+        HTTPSessionManager.useLiveData()
+
+        super.tearDown()
+    }
+
+    //MARK: - Test generic closures in API completion
+
+    func testDictionaryFetch() {
+        //GIVEN: Using mock data and an async method
+        let expectation = self.expectation(description: "Finish requesting dictionary")
+        
+        //WHEN: Requesting a URL that should return a dictionary
+        MainAPIUtility.sharedUtility.getJSON(from: "fetchDictionary",
+                                             headers: [:],
+                                             success: { (result: [String: Any]) in
+                                                //THEN: the result data type is dictionary as expected
+                                                expectation.fulfill()
+        }, failure: { error in
+            XCTFail("Failed to fetch a dictionary. Error: \(error)")
+            expectation.fulfill()
+        })
+        
+        self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
+    }
+
+    func testArrayFetch() {
+        //GIVEN: Using mock data and an async method
+        let expectation = self.expectation(description: "Finish requesting array")
+
+        //WHEN: Requesting a URL that should return an array
+        MainAPIUtility.sharedUtility.getJSON(from: "fetchArray",
+                                             headers: [:],
+                                             success: { (result: [Any]) in
+                                                //THEN: the result data type is array as expected
+                                                expectation.fulfill()
+        }, failure: { error in
+            XCTFail("Failed to fetch an array. Error: \(error)")
+            expectation.fulfill()
+        })
+        
+        self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
+    }
+
+    func testArrayFail() {
+        //GIVEN: Using mock data and an async method
+        let expectation = self.expectation(description: "Finish requesting array")
+
+        //WHEN: Requesting a URL that should return an array
+        MainAPIUtility.sharedUtility.getJSON(from: "failArray",
+                                             headers: [:],
+                                             success: { (result: [Any]) in
+                                                XCTFail("This should fail: mock data does not contain an array")
+                                                expectation.fulfill()
+        }, failure: { error in
+            //THEN: the result data type is NOT array as requested, becuase mock data contains a dictionary
+            expectation.fulfill()
+        })
+        
+        self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
+    }
+
+    func testDictionaryFail() {
+        //GIVEN: Using mock data and an async method
+        let expectation = self.expectation(description: "Finish requesting dictionary")
+
+        //WHEN: Requesting a URL that should return a dictionary
+        MainAPIUtility.sharedUtility.getJSON(from: "failDictionary",
+                                             headers: [:],
+                                             success: { (result: [String: Any]) in
+                                                XCTFail("This should fail: mock data does not contain a dictionary")
+                                                expectation.fulfill()
+        }, failure: { error in
+            //THEN: the result data  type is NOT dictionary as requested, becuase mock data contains an array
+            expectation.fulfill()
+        })
+        
+        self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
+    }
+    
+}

--- a/Vokal-Swift.xctemplate/APICompletionTests.swift
+++ b/Vokal-Swift.xctemplate/APICompletionTests.swift
@@ -118,4 +118,23 @@ class APICompletionTests: XCTestCase {
         self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
     }
     
+    func testEmptyResponse() {
+        //GIVEN: Using mock data and an async method
+        let expectation = self.expectation(description: "Finish making POST request")
+        
+        //WHEN: Requesting a URL that should return a 204 No Content
+        let fakeParams: APIDictionary = ["id": 123]
+        MainAPIUtility.sharedUtility.postJSON(to: "emptyResponse",
+                                              headers: [:],
+                                              params: fakeParams,
+                                              success: { (result: NSNull) in
+                                                //THEN: the result data type is null as expected
+                                                expectation.fulfill()
+        }, failure: { error in
+                XCTFail("API request failed. Error: \(error)")
+                expectation.fulfill()
+        })
+        
+        self.waitForExpectations(timeout: StandardTestTimeout, handler: nil)
+    }
 }

--- a/Vokal-Swift.xctemplate/APICompletionTests.swift
+++ b/Vokal-Swift.xctemplate/APICompletionTests.swift
@@ -38,7 +38,7 @@ class APICompletionTests: XCTestCase {
         //WHEN: Requesting a URL that should return a dictionary
         MainAPIUtility.sharedUtility.getJSON(from: "fetchDictionary",
                                              headers: [:],
-                                             success: { (result: [String: Any]) in
+                                             success: { (result: APIDictionary) in
                                                 //THEN: the result data type is dictionary as expected
                                                 expectation.fulfill()
         }, failure: { error in
@@ -56,7 +56,7 @@ class APICompletionTests: XCTestCase {
         //WHEN: Requesting a URL that should return an array
         MainAPIUtility.sharedUtility.getJSON(from: "fetchArray",
                                              headers: [:],
-                                             success: { (result: [Any]) in
+                                             success: { (result: APIArray) in
                                                 //THEN: the result data type is array as expected
                                                 expectation.fulfill()
         }, failure: { error in
@@ -74,7 +74,7 @@ class APICompletionTests: XCTestCase {
         //WHEN: Requesting a URL that should return an array
         MainAPIUtility.sharedUtility.getJSON(from: "failArray",
                                              headers: [:],
-                                             success: { (result: [Any]) in
+                                             success: { (result: APIArray) in
                                                 XCTFail("This should fail: mock data does not contain an array")
                                                 expectation.fulfill()
         }, failure: { error in
@@ -100,7 +100,7 @@ class APICompletionTests: XCTestCase {
         //WHEN: Requesting a URL that should return a dictionary
         MainAPIUtility.sharedUtility.getJSON(from: "failDictionary",
                                              headers: [:],
-                                             success: { (result: [String: Any]) in
+                                             success: { (result: APIDictionary) in
                                                 XCTFail("This should fail: mock data does not contain a dictionary")
                                                 expectation.fulfill()
         }, failure: { error in

--- a/Vokal-Swift.xctemplate/APICompletionTests.swift
+++ b/Vokal-Swift.xctemplate/APICompletionTests.swift
@@ -79,6 +79,14 @@ class APICompletionTests: XCTestCase {
                                                 expectation.fulfill()
         }, failure: { error in
             //THEN: the result data type is NOT array as requested, becuase mock data contains a dictionary
+            switch error {
+            case .unexpectedReturnType:
+                // This is the expected error for this test
+                break
+            default:
+                XCTFail("Should get unexpected return type here")
+            }
+
             expectation.fulfill()
         })
         
@@ -96,7 +104,14 @@ class APICompletionTests: XCTestCase {
                                                 XCTFail("This should fail: mock data does not contain a dictionary")
                                                 expectation.fulfill()
         }, failure: { error in
-            //THEN: the result data  type is NOT dictionary as requested, becuase mock data contains an array
+            //THEN: the result data type is NOT dictionary as requested, becuase mock data contains an array
+            switch error {
+            case .unexpectedReturnType:
+            // This is the expected error for this test
+                break
+            default:
+                XCTFail("Should get unexpected return type here")
+            }
             expectation.fulfill()
         })
         

--- a/Vokal-Swift.xctemplate/MainAPIUtility.swift
+++ b/Vokal-Swift.xctemplate/MainAPIUtility.swift
@@ -9,10 +9,15 @@
 import Foundation
 import Alamofire
 
-//MARK: - Completion Closures
+//MARK: - Completion Closures and type aliases
 
-typealias APISuccessCompletion = ([String: Any]) -> Void
+typealias APIDictionary = [String: Any]
+typealias APIArray = [Any]
+
+typealias APISuccessCompletion<T> = (T) -> Void
 typealias APIFailureCompletion = (NetworkError) -> Void
+typealias APIDictionaryCompletion = (APIDictionary) -> Void
+typealias APIArrayCompletion = (APIArray) -> Void
 
 //MARK: - Header enums
 
@@ -139,9 +144,9 @@ class MainAPIUtility {
     
     func postUserJSON(to path: String,
                       headers: [HTTPHeaderKey: HTTPHeaderValue],
-                      params: [String: Any],
+                      params: APIDictionary,
                       userEmail: String,
-                      success: @escaping APISuccessCompletion,
+                      success: @escaping APIDictionaryCompletion,
                       failure: @escaping APIFailureCompletion) {
         
         let fullURLString = ServerEnvironment.fullURLString(for: path)
@@ -154,12 +159,13 @@ class MainAPIUtility {
                      parameters: params,
                      encoding: JSONEncoding.default,
                      headers: headerStrings)
+            .validate()
             .responseJSON {
                 [weak self]
                 response in
                 
                 if response.result.isSuccess {
-                    if let dict = response.result.value as? [String: AnyObject],
+                    if let dict = response.result.value as? APIDictionary,
                         let token = dict["token"] as? String {
                         TokenStorageHelper.store(authorizationToken: token, forEmail: userEmail)
                     }
@@ -171,10 +177,10 @@ class MainAPIUtility {
         }
     }
     
-    func getJSON(from path: String,
+    func getJSON<T>(from path: String,
                  headers: [HTTPHeaderKey: HTTPHeaderValue],
-                 params: [String: Any]? = nil,
-                 success: @escaping APISuccessCompletion,
+                 params: APIDictionary? = nil,
+                 success: @escaping APISuccessCompletion<T>,
                  failure: @escaping APIFailureCompletion) {
         
         let fullURLString = ServerEnvironment.fullURLString(for: path)
@@ -187,6 +193,7 @@ class MainAPIUtility {
                      parameters: params,
                      encoding: URLEncoding.default,
                      headers: headerStrings)
+            .validate()
             .responseJSON {
                 [weak self]
                 response in
@@ -197,10 +204,10 @@ class MainAPIUtility {
         }
     }
     
-    func postJSON(to path: String,
+    func postJSON<T>(to path: String,
                   headers: [HTTPHeaderKey: HTTPHeaderValue],
-                  params: [String: Any],
-                  success: @escaping APISuccessCompletion,
+                  params: APIDictionary,
+                  success: @escaping APISuccessCompletion<T>,
                   failure: @escaping APIFailureCompletion) {
         
         let fullURLString = ServerEnvironment.fullURLString(for: path)
@@ -213,6 +220,7 @@ class MainAPIUtility {
                      parameters: params,
                      encoding: JSONEncoding.default,
                      headers: headerStrings)
+            .validate()
             .responseJSON {
                 [weak self]
                 response in
@@ -224,35 +232,28 @@ class MainAPIUtility {
     
     //MARK: Handler for methods expecting a dictionary on success
     
-    private func handle(response: DataResponse<Any>,
-                        success: @escaping APISuccessCompletion,
+    private func handle<T>(response: DataResponse<Any>,
+                        success: @escaping APISuccessCompletion<T>,
                         failure: @escaping APIFailureCompletion) {
         
         if shouldDebugPrintInfo {
             debugPrint(response)
         }
         
-        if let httpResponse = response.response {
-            let statusCode = httpResponse.statusCode
-            
-            if (statusCode < 200 || statusCode >= 300) {
-                //This is actually an error.
-                let error = NetworkError.from(statusCode: statusCode)
-                failure(error)
-                return
-            }
-        }
-        
         switch response.result {
         case .success(let value):
-            // Make sure the returned value is a dictionary as expected
-            if let dict = value as? [String: Any] {
-                success(dict)
+            // Make sure the returned value is the type expected for the success block
+            if let responseValue = value as? T {
+                success(responseValue)
             } else {
                 failure(NetworkError.unexpectedReturnType)
             }
         case .failure(let error):
-            failure(NetworkError.otherError(error: error))
+            if let httpResponse = response.response {
+                failure(NetworkError.from(statusCode: httpResponse.statusCode))
+            } else {
+                failure(NetworkError.otherError(error: error))
+            }
         }
         
     }

--- a/Vokal-Swift.xctemplate/MainAPIUtility.swift
+++ b/Vokal-Swift.xctemplate/MainAPIUtility.swift
@@ -14,10 +14,20 @@ import Alamofire
 typealias APIDictionary = [String: Any]
 typealias APIArray = [Any]
 
+// Generic completion closure for API requests
 typealias APISuccessCompletion<T> = (T) -> Void
+
+// Failure completion closure for API requests
 typealias APIFailureCompletion = (NetworkError) -> Void
+
+// Completion closure for API requests that return a dictionary
 typealias APIDictionaryCompletion = (APIDictionary) -> Void
+
+// Completion closure for API requests that return an array
 typealias APIArrayCompletion = (APIArray) -> Void
+
+// Completion closure for API requests that return 204 No Content
+typealias APIEmptyResponseCompletion = (NSNull) -> Void
 
 //MARK: - Header enums
 
@@ -230,8 +240,8 @@ class MainAPIUtility {
         }
     }
     
-    //MARK: Handler for methods expecting a dictionary on success
-    
+    //MARK: Common handler for API responses
+
     private func handle<T>(response: DataResponse<Any>,
                         success: @escaping APISuccessCompletion<T>,
                         failure: @escaping APIFailureCompletion) {

--- a/Vokal-Swift.xctemplate/ResetPasswordAPI.swift
+++ b/Vokal-Swift.xctemplate/ResetPasswordAPI.swift
@@ -28,6 +28,12 @@ struct ResetPasswordAPI {
         Confirm = "password-reset/confirm"
     }
     
+    private static var headerDict: [HTTPHeaderKey: HTTPHeaderValue] {
+        return MainAPIUtility
+            .sharedUtility
+            .requestHeaders(withAuthToken: false)
+    }
+
     //MARK: - Reset Password Methods
     
     /**
@@ -41,19 +47,18 @@ struct ResetPasswordAPI {
      - parameter failure:     The closure to execute if the request fails.
      */
     static func requestPasswordReset(forEmail email: String,
-                                     success: @escaping APISuccessCompletion,
+                                     success: @escaping APIDictionaryCompletion,
                                      failure: @escaping APIFailureCompletion) {
         let parameters = [
             JSONKey.RequestEmail.rawValue: email
         ]
         
         let resetPasswordRequestPath = PasswordResetPath.Request.path(forVersion: .v1)
-        let headers = headerDict()
         
         MainAPIUtility
             .sharedUtility
             .postJSON(to: resetPasswordRequestPath,
-                      headers: headers,
+                      headers: self.headerDict,
                       params: parameters,
                       success: success,
                       failure: failure)
@@ -69,7 +74,7 @@ struct ResetPasswordAPI {
      */
     static func resetPassword(withCode code: String,
                               updatedPassword: String,
-                              success: @escaping APISuccessCompletion,
+                              success: @escaping APIDictionaryCompletion,
                               failure: @escaping APIFailureCompletion) {
         
         let parameters = [
@@ -77,20 +82,14 @@ struct ResetPasswordAPI {
             JSONKey.UpdatedPassword.rawValue: updatedPassword
         ]
         let resetPasswordPath = PasswordResetPath.Confirm.path(forVersion: .v1)
-        let headers = headerDict()
         
         MainAPIUtility
             .sharedUtility
             .postJSON(to: resetPasswordPath,
-                      headers: headers,
+                      headers: self.headerDict,
                       params: parameters,
                       success: success,
                       failure:failure)
     }
-    
-    private static func headerDict() -> [HTTPHeaderKey: HTTPHeaderValue] {
-        return MainAPIUtility
-            .sharedUtility
-            .requestHeaders(withAuthToken: false)
-    }
+
 }

--- a/Vokal-Swift.xctemplate/TemplateInfo.plist
+++ b/Vokal-Swift.xctemplate/TemplateInfo.plist
@@ -414,6 +414,15 @@
 								<string>MoveToNonUITestTarget</string>
 							</array>
 						</dict>
+						<key>MoveToNonUITestTarget/APICompletionTests.swift</key>
+						<dict>
+							<key>Path</key>
+							<string>APICompletionTests.swift</string>
+							<key>Group</key>
+							<array>
+								<string>MoveToNonUITestTarget</string>
+							</array>
+						</dict>
 						<key>MoveToNonUITestTarget/UserAPITests.swift</key>
 						<dict>
 							<key>Path</key>
@@ -446,6 +455,7 @@
 						<string>MoveToNonUITestTarget/HTTPSessionManager+MockData.swift</string>
 						<string>MoveToNonUITestTarget/TokenStorageHelperTests.swift</string>
 						<string>MoveToNonUITestTarget/UserAPITests.swift</string>
+						<string>MoveToNonUITestTarget/APICompletionTests.swift</string>
 						<string>MoveToNonUITestTarget/VOKMockData</string>
 					</array>
 					<key>Targets</key>

--- a/Vokal-Swift.xctemplate/UserAPI.swift
+++ b/Vokal-Swift.xctemplate/UserAPI.swift
@@ -59,7 +59,7 @@ struct UserAPI {
      */
     static func register(withEmail email: String,
                          password: String,
-                         success: @escaping APISuccessCompletion,
+                         success: @escaping APIDictionaryCompletion,
                          failure: @escaping APIFailureCompletion) {
         let parameters = [
             JSONKey.Email.rawValue: email,
@@ -89,7 +89,7 @@ struct UserAPI {
      */
     static func login(withEmail email: String,
                       password: String,
-                      success: @escaping APISuccessCompletion,
+                      success: @escaping APIDictionaryCompletion,
                       failure: @escaping APIFailureCompletion) {
         let parameters = [
             JSONKey.Email.rawValue: email,
@@ -119,7 +119,7 @@ struct UserAPI {
      */
     static func facebookLoginOrRegister(withFacebookID facebookID: String,
                                         facebookToken: String,
-                                        success: @escaping APISuccessCompletion,
+                                        success: @escaping APIDictionaryCompletion,
                                         failure: @escaping APIFailureCompletion) {
         
         let parameters = [
@@ -148,7 +148,7 @@ struct UserAPI {
      - parameter success:     The closure to execute if the request succeeds.
      - parameter failure:     The closure to execute if the request fails.
      */
-    static func fetchCurrentUserInfo(success: @escaping APISuccessCompletion,
+    static func fetchCurrentUserInfo(success: @escaping APIDictionaryCompletion,
                                      failure: @escaping APIFailureCompletion) {
         let currentUserFetchPath = GETPath.CurrentUser.path(forVersion: .v1)
         let headers = self.requestHeaders(withAuthToken: true)
@@ -169,10 +169,11 @@ struct UserAPI {
      - parameter success:     The closure to execute if the request succeeds.
      - parameter failure:     The closure to execute if the request fails.
      */
+    // TODO: maybe expect an empty response here
     static func registerCurrentUserForNotifications(withToken deviceToken: String,
-                                                    success: @escaping APISuccessCompletion,
+                                                    success: @escaping APIDictionaryCompletion,
                                                     failure: @escaping APIFailureCompletion) {
-        
+
         let parameters = [
             JSONKey.PushNotificationToken.rawValue: deviceToken
         ]
@@ -199,7 +200,7 @@ struct UserAPI {
      - parameter failure:     The closure to execute if the request fails.
      */
     static func fetchUserInfo(forUserID userID: String,
-                              success: @escaping APISuccessCompletion,
+                              success: @escaping APIDictionaryCompletion,
                               failure: @escaping APIFailureCompletion) {
         let userFetchPath = APIVersion.v1.versioned(path: GETPath.specificUser(userID: userID))
         let headers = self.requestHeaders(withAuthToken: true)

--- a/Vokal-Swift.xctemplate/VOKMockData/GET|-failArray.http
+++ b/Vokal-Swift.xctemplate/VOKMockData/GET|-failArray.http
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Server: nginx/1.4.6 (Ubuntu)
+Date: Wed, 29 Oct 2014 16:46:48 GMT
+Content-Type: application/json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Vary: Accept
+X-Frame-Options: SAMEORIGIN
+Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+
+{
+"one":"two"
+}

--- a/Vokal-Swift.xctemplate/VOKMockData/GET|-failDictionary.http
+++ b/Vokal-Swift.xctemplate/VOKMockData/GET|-failDictionary.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx/1.4.6 (Ubuntu)
+Date: Wed, 29 Oct 2014 16:46:48 GMT
+Content-Type: application/json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Vary: Accept
+X-Frame-Options: SAMEORIGIN
+Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+
+[
+    "token",
+    "Some other token",
+    "bananas",
+    {"subobj": 4}
+]

--- a/Vokal-Swift.xctemplate/VOKMockData/GET|-fetchArray.http
+++ b/Vokal-Swift.xctemplate/VOKMockData/GET|-fetchArray.http
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Server: nginx/1.4.6 (Ubuntu)
+Date: Wed, 29 Oct 2014 16:46:48 GMT
+Content-Type: application/json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Vary: Accept
+X-Frame-Options: SAMEORIGIN
+Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+
+[
+"one","two",3
+]

--- a/Vokal-Swift.xctemplate/VOKMockData/GET|-fetchDictionary.http
+++ b/Vokal-Swift.xctemplate/VOKMockData/GET|-fetchDictionary.http
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Server: nginx/1.4.6 (Ubuntu)
+Date: Wed, 29 Oct 2014 16:46:48 GMT
+Content-Type: application/json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Vary: Accept
+X-Frame-Options: SAMEORIGIN
+Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+
+{
+    "token": "Some other token",
+    "bananas": {"subobj": 4}
+}

--- a/Vokal-Swift.xctemplate/VOKMockData/POST|-emptyResponse|d2-idi123ee.http
+++ b/Vokal-Swift.xctemplate/VOKMockData/POST|-emptyResponse|d2-idi123ee.http
@@ -1,0 +1,10 @@
+HTTP/1.1 204 No Content
+Server: nginx/1.4.6 (Ubuntu)
+Date: Wed, 29 Oct 2014 16:46:48 GMT
+Content-Type: application/json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Vary: Accept
+X-Frame-Options: SAMEORIGIN
+Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+


### PR DESCRIPTION
- Generics in success closures for API calls
- Better response handling, to differentiate success/failure
- Take advantage of Alamofire's `validate()` method to check response status code and Content-type
- No special handling for 204 response, but `APIEmptyResponseCompletion` demonstrates the closure signature for it
- Tests for these changes

@vokal/ios-developers code review please?