### PR TITLE
A few Fastlane updates

### DIFF
--- a/Vokal-Cocoa Touch Application Base.xctemplate/.gitignore
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/.gitignore
@@ -38,3 +38,4 @@ fastlane/local_config.sh
 fastlane/test_output
 fastlane/Provisioning
 fastlane/Build
+fastlane/report.xml

--- a/Vokal-Cocoa Touch Application Base.xctemplate/Gemfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'cocoapods', '~>1.2'
-gem 'fastlane', '~>2.13'
+gem 'fastlane', '~>2.27.0'
 gem 'slather', '~>2.3'

--- a/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/Version_Incrementing_Run_Script.sh
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/Scripts/Version_Incrementing_Run_Script.sh
@@ -3,7 +3,7 @@
 # Update the Info.plist build number with number of git commits
 buildNumber=$(git rev-list HEAD --count) \
     || exit 1
-echo "Updating build number to ${buildNumber}..."
+echo "note: Updating build number to ${buildNumber}..."
 
 # Update the Info.plist build number with number of git commits
 /usr/libexec/PlistBuddy \
@@ -21,16 +21,20 @@ if [[ -e "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist"
 fi
 
 # Update the Settings.bundle
-bundleShortVersionString=$(/usr/libexec/PlistBuddy \
-    -c "Print :CFBundleShortVersionString" \
-    "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" \
-    ) \
-    || exit 1
-newVersion="${bundleShortVersionString} (${buildNumber})"
-echo "Setting version number in settings bundle to ${newVersion}..."
-/usr/libexec/PlistBuddy \
-    -c "Set PreferenceSpecifiers:1:DefaultValue ${newVersion}" \
-    "${TARGET_BUILD_DIR}"/"${PRODUCT_NAME}.app"/Settings.bundle/Root.plist \
-    || exit 1
+settingsBundlePlistPath="${TARGET_BUILD_DIR}/${PRODUCT_NAME}.app/Settings.bundle/Root.plist"
 
-echo "Done."
+if [[ -e "${settingsBundlePlistPath}" ]]; then
+    bundleShortVersionString=$(/usr/libexec/PlistBuddy \
+        -c "Print :CFBundleShortVersionString" \
+        "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" \
+        ) \
+        || exit 1
+    newVersion="${bundleShortVersionString} (${buildNumber})"
+    echo "note: Setting version number in settings bundle to ${newVersion}..."
+    /usr/libexec/PlistBuddy \
+        -c "Set PreferenceSpecifiers:1:DefaultValue ${newVersion}" \
+        "${settingsBundlePlistPath}" \
+        || exit 1
+fi
+
+echo "note: Done."

--- a/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
@@ -30,16 +30,6 @@ platform :ios do
     main_scheme,
   ]
 
-  # The SDK to use build and run tests. Left as is, will use the highest
-  # available SDK.  If more specificity is required, should be of the format
-  # 'iphonesimulatorX.X'
-  test_sdk = 'iphonesimulator'
-
-  # The SDK to use to archive builds. Left as is, will use the highest
-  # available SDK.  If more specificity is required, should be of the format
-  # 'iphoneosX.X'
-  archive_sdk = 'iphoneos'
-
   # The build configuration to use when creating an archive build
   archive_build_configuration = 'Release'
 
@@ -113,7 +103,6 @@ platform :ios do
     scan(
       workspace: workspace_file,
       scheme: scheme,
-      sdk: test_sdk,
       derived_data_path: build_folder,
       output_directory: File.join(fastlane_folder, output_folder),
       skip_build: true, #the test action will already kick off a build, don't build twice
@@ -207,7 +196,6 @@ platform :ios do
       output_directory: build_folder,
       include_bitcode: false,
       include_symbols: true,
-      sdk: archive_sdk,
       xcargs: xcargs,
       clean: true,
     )

--- a/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
@@ -378,6 +378,7 @@ platform :ios do
       username: itc_username,
       changelog: "This PRODUCTION build was automatically uploaded by Fastlane - DO NOT SUBMIT FOR TEST FLIGHT OR THE APP STORE UNTIL RELEASE NOTES ARE UPDATED!!!!",
       distribute_external: false,
+      skip_waiting_for_build_processing: true,
       skip_submission: true,
     )
   end


### PR DESCRIPTION
This pr has a few  Fastlane related updates:

- Added fastlane/report.xml to .gitignore.
- Use latest Fastlane in Gemfile.
- Don't wait for the iTunes Connect build to finish processing when running Fastlane.
- Remove the archive and test sdk usage from the Fastfile as this will cause issues with targets that are not iOS (ex watch, tv, etc).
- Update the version incrementing run script to handle targets that don't have a settings bundle.

@vokal/ios-developers review please