### PR TITLE
Fix Xcode 9 template grouping issue

### DIFF
--- a/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
@@ -14,34 +14,6 @@
 	</array>
 	<key>Definitions</key>
 	<dict>
-		<key>Categories</key>
-		<dict>
-			<key>Path</key>
-			<string>Categories</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>Extensions</key>
-		<dict>
-			<key>Path</key>
-			<string>Extensions</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>View Controllers</key>
-		<dict>
-			<key>Path</key>
-			<string>View Controllers</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>Views</key>
-		<dict>
-			<key>Path</key>
-			<string>Views</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
 		<key>Views/.gitkeep</key>
 		<dict>
 			<key>Group</key>
@@ -50,13 +22,6 @@
 			</array>
 			<key>Path</key>
 			<string>.gitkeep</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>Controls</key>
-		<dict>
-			<key>Path</key>
-			<string>Controls</string>
 			<key>TargetIndices</key>
 			<array/>
 		</dict>
@@ -71,13 +36,6 @@
 			<key>TargetIndices</key>
 			<array/>
 		</dict>
-		<key>Data Sources</key>
-		<dict>
-			<key>Path</key>
-			<string>Data Sources</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
 		<key>Data Sources/.gitkeep</key>
 		<dict>
 			<key>Group</key>
@@ -89,13 +47,6 @@
 			<key>TargetIndices</key>
 			<array/>
 		</dict>
-		<key>Resources</key>
-		<dict>
-			<key>Path</key>
-			<string>Resources</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
 		<key>Resources/___PACKAGENAME___.truecolors</key>
 		<dict>
 			<key>Group</key>
@@ -104,15 +55,6 @@
 			</array>
 			<key>Path</key>
 			<string>___PACKAGENAME___.truecolors</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>Resources/Fonts</key>
-		<dict>
-			<key>Group</key>
-			<string>Resources</string>
-			<key>Path</key>
-			<string>Fonts</string>
 			<key>TargetIndices</key>
 			<array/>
 		</dict>
@@ -128,15 +70,6 @@
 			<key>TargetIndices</key>
 			<array/>
 		</dict>
-		<key>Resources/TrueColors</key>
-		<dict>
-			<key>Group</key>
-			<string>Resources</string>
-			<key>Path</key>
-			<string>TrueColors</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
 		<key>Resources/TrueColors/.gitkeep</key>
 		<dict>
 			<key>Group</key>
@@ -146,13 +79,6 @@
 			</array>
 			<key>Path</key>
 			<string>.gitkeep</string>
-			<key>TargetIndices</key>
-			<array/>
-		</dict>
-		<key>Scripts</key>
-		<dict>
-			<key>Path</key>
-			<string>Scripts</string>
 			<key>TargetIndices</key>
 			<array/>
 		</dict>

--- a/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
@@ -120,7 +120,7 @@
 		<dict>
 			<key>Group</key>
 			<array>
-			    <string>Resources</string>
+				<string>Resources</string>
 				<string>Fonts</string>
 			</array>
 			<key>Path</key>
@@ -141,7 +141,7 @@
 		<dict>
 			<key>Group</key>
 			<array>
-			    <string>Resources</string>
+				<string>Resources</string>
 				<string>TrueColors</string>
 			</array>
 			<key>Path</key>
@@ -233,7 +233,7 @@ end
 post_install do | installer |
     # Update acknowledgements in the Settings.bundle from pods automagically
     require &apos;fileutils&apos;
-    FileUtils.cp_r(&apos;Pods/Target Support Files/Pods-___PACKAGENAME___/Pods-___PACKAGENAME___-acknowledgements.plist&apos;, &apos;___PACKAGENAME___/Settings.bundle/Acknowledgements.plist&apos;, :remove_destination => true)
+    FileUtils.cp_r(&apos;Pods/Target Support Files/Pods-___PACKAGENAME___/Pods-___PACKAGENAME___-acknowledgements.plist&apos;, &apos;___PACKAGENAME___/Settings.bundle/Acknowledgements.plist&apos;, :remove_destination =&gt; true)
 end
 </string>
 			<key>Group</key>
@@ -367,22 +367,14 @@ end
 			<string>Settings.bundle</string>
 		</dict>
 	</dict>
-    
 	<key>Nodes</key>
 	<array>
-		<string>Controls</string>
 		<string>Controls/.gitkeep</string>
-		<string>Data Sources</string>
 		<string>Data Sources/.gitkeep</string>
-		<string>Resources</string>
 		<string>Resources/___PACKAGENAME___.truecolors</string>
-		<string>Resources/Fonts</string>
 		<string>Resources/Fonts/.gitkeep</string>
-		<string>Resources/TrueColors</string>
 		<string>Resources/TrueColors/.gitkeep</string>
-		<string>Views</string>
 		<string>Views/.gitkeep</string>
-		<string>View Controllers</string>
 		<string>../Gemfile</string>
 		<string>../Podfile</string>
 		<string>../travis</string>
@@ -400,7 +392,6 @@ end
 		<string>Info.plist:UIRequiredDeviceCapabilities:base</string>
 		<string>Base.lproj/LaunchScreen.xib</string>
 		<string>Base.lproj/Main-___PACKAGENAME___.storyboard</string>
-		<string>Scripts</string>
 		<string>Scripts/Version_Incrementing_Run_Script.sh</string>
 		<string>Scripts/xUnique_Run_Script.sh</string>
 		<string>Scripts/DevsJustWantToHaveFun.sh</string>
@@ -529,7 +520,7 @@ end
 					<key>ShellPath</key>
 					<string>/bin/bash</string>
 					<key>ShellScript</key>
-					<string>"${SRCROOT}/___PACKAGENAME___/Scripts/Version_Incrementing_Run_Script.sh"</string>
+					<string>&quot;${SRCROOT}/___PACKAGENAME___/Scripts/Version_Incrementing_Run_Script.sh&quot;</string>
 				</dict>
 			</array>
 			<key>ProductType</key>

--- a/Vokal-ObjC.xctemplate/TemplateInfo.plist
+++ b/Vokal-ObjC.xctemplate/TemplateInfo.plist
@@ -67,7 +67,6 @@
 	<key>Nodes</key>
 	<array>
 		<string>../VokalObjCleanStyleSettings.plist</string>
-		<string>Categories</string>
 		<string>Categories/.gitkeep</string>
 		<string>main.m</string>
 		<string>Prefix.pch</string>
@@ -398,7 +397,6 @@
 				<string>Base</string>
 			</array>
 		</dict>
-
 	</dict>
 	<key>Project</key>
 	<dict>
@@ -447,7 +445,7 @@
 					<key>Definitions</key>
 					<dict>
 						<key>../Podfile:afpod</key>
-						<string>    pod &apos;AFNetworking&apos;, &apos;~> 3.1&apos;</string>
+						<string>    pod &apos;AFNetworking&apos;, &apos;~&gt; 3.1&apos;</string>
 					</dict>
 					<key>Nodes</key>
 					<array>

--- a/Vokal-Swift.xctemplate/TemplateInfo.plist
+++ b/Vokal-Swift.xctemplate/TemplateInfo.plist
@@ -99,7 +99,6 @@
 	</array>
 	<key>Nodes</key>
 	<array>
-		<string>Extensions</string>
 		<string>Extensions/ReuseIdentifiable.swift</string>
 		<string>main.swift</string>
 		<string>../R.generated.swift</string>
@@ -343,9 +342,9 @@
 					<key>Definitions</key>
 					<dict>
 						<key>../Podfile:afpod</key>
-						<string>    pod &apos;Alamofire&apos;, &apos;~> 4.0&apos;</string>
+						<string>    pod &apos;Alamofire&apos;, &apos;~&gt; 4.0&apos;</string>
 						<key>../Podfile:ilghttp</key>
-						<string>    pod &apos;ILGHttpConstants&apos;, &apos;~> 2.0&apos;</string>
+						<string>    pod &apos;ILGHttpConstants&apos;, &apos;~&gt; 2.0&apos;</string>
 					</dict>
 					<key>Nodes</key>
 					<array>
@@ -375,7 +374,7 @@
 					<key>Definitions</key>
 					<dict>
 						<key>../Podfile:swiftkeychainwrapper</key>
-						<string>    pod &apos;SwiftKeychainWrapper&apos;, &apos;~> 3.0&apos;</string>
+						<string>    pod &apos;SwiftKeychainWrapper&apos;, &apos;~&gt; 3.0&apos;</string>
 					</dict>
 					<key>Nodes</key>
 					<array>
@@ -561,7 +560,7 @@
 							<string>CoreDataAndModels</string>
 						</dict>
 						<key>../Podfile:vokoderpod</key>
-						<string>    pod &apos;Vokoder/Swift&apos;, &apos;~> 4.0.1&apos;</string>
+						<string>    pod &apos;Vokoder/Swift&apos;, &apos;~&gt; 4.0.1&apos;</string>
 						<key>Scripts/MOGenerator.sh</key>
 						<dict>
 							<key>TargetIndices</key>


### PR DESCRIPTION
This pr fixes #36 which is an issue in Xcode 9 (but not Xcode 8) that would cause groups to be duplicated when creating new projects with the template.

@vokal/ios-developers review please

Note this pr is in the Xcode 9 branch and will eventually be merged to `master` later after Xcode 9 is released.