### PR TITLE
 Fix Fastfile naming collision

### DIFF
--- a/Vokal-Cocoa Touch Application Base.xctemplate/.travis.yml
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.2
 before_install:
   - echo -e "machine github.com\n login ${CI_USER_TOKEN}" >> ~/.netrc
 before_script:

--- a/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
@@ -103,7 +103,7 @@ platform :ios do
   desc "Expects values for the following keys:"
   desc "scheme_options_key: The name of the scheme to use to run the tests"
   desc "output_options_key: The path to output information from the tests"
-  private_lane :run_tests do |options|
+  private_lane :do_tests do |options|
     if !options.key?(:scheme_options_key) || !options.key?(:output_options_key)
       raise "Not all required options for this lane are present!"
       return
@@ -163,7 +163,7 @@ platform :ios do
       end
 
       # Run the tests
-      run_tests(
+      do_tests(
         scheme_options_key: scheme,
         output_options_key: scheme_output_folder,
       )

--- a/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Matchfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Matchfile
@@ -5,6 +5,9 @@ git_url "https://github.com/vokal/certificates-iOS.git"
 # team (or client company), which might differ from the name of the app.
 git_branch "___PACKAGENAME___"
 
+# Clone just the branch rather than the whole repo to save time
+clone_branch_directly true
+
 # The default type, can be: appstore, adhoc or development
 type "adhoc" 
 


### PR DESCRIPTION
This pr fixes a recent naming collision in the Fastfile. Fastlane 2.6.8 renamed/aliased `scan` to `run_tests`, which was causing a naming collision with our Fastfile, which had its own `run_tests` private lane.

Also updated the Matchfile to clone the branch directly. Also updated the Travis osx image to 9.2.

@vokal/ios-developers review please