### PR TITLE
Add Swift Array safe subscript

### DIFF
--- a/Vokal-Cocoa Touch Application Base.xctemplate/Gemfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-gem 'cocoapods', '~>1.3'
-gem 'fastlane', '~>2.61.0'
+gem 'cocoapods', '~>1.4'
+gem 'fastlane'
 gem 'slather', '~>2.4'

--- a/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
@@ -135,7 +135,7 @@
 			<string>source &apos;https://github.com/vokal/PrivatePodspecRepo-iOS.git&apos;
 source &apos;https://github.com/CocoaPods/Specs.git&apos;
 
-platform :ios, &apos;9.0&apos;
+platform :ios, &apos;11.0&apos;
 
 target &apos;___PACKAGENAME___&apos; do
     pod &apos;xUnique&apos;

--- a/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/fastlane/Fastfile
@@ -64,6 +64,8 @@ platform :ios do
     '___PACKAGENAME___/*TestingAppDelegate.*',
     '___PACKAGENAME___/Resources/TrueColors/*',
     '___PACKAGENAME___/Utilities/DLog.swift',
+    '___PACKAGENAME___/Views/Base/*',
+    '___PACKAGENAME___/Controls/Base/*',
     'Pods/*',
   ]
 

--- a/Vokal-Swift.xctemplate/.swiftlint.yml
+++ b/Vokal-Swift.xctemplate/.swiftlint.yml
@@ -1,16 +1,17 @@
 disabled_rules:
-  - trailing_whitespace
-  - variable_name
-  - todo
-  - type_name
-  - function_parameter_count
-  - type_body_length
-  - function_body_length
+  - control_statement
+  - cyclomatic_complexity
   - file_length
+  - function_body_length
+  - function_parameter_count
   - line_length
   - nesting
-  - cyclomatic_complexity
-  - control_statement
+  - todo
+  - trailing_whitespace
+  - type_body_length
+  - type_name
+  - unused_optional_binding
+  - variable_name
 
 opt_in_rules:
   - force_unwrapping

--- a/Vokal-Swift.xctemplate/ArrayExtensions.swift
+++ b/Vokal-Swift.xctemplate/ArrayExtensions.swift
@@ -1,0 +1,20 @@
+//
+//  ___FILENAME___
+//  ___PACKAGENAME___
+//
+//  Created by ___FULLUSERNAME___ on ___DATE___.
+//  ___COPYRIGHT___
+//
+
+import Foundation
+
+extension Array {
+    /// Safely subscript into an array. This will perform a bounds check on the passed in index.
+    ///
+    /// - Parameter index: the index to look up in the array.
+    /// - Returns: an element if the index is within bounds of the array; otherwise, nil.
+    subscript(safe index: Index) -> Element? {
+        guard self.indices.contains(index) else { return nil }
+        return self[index]
+    }
+}

--- a/Vokal-Swift.xctemplate/ArrayExtensionsTests.swift
+++ b/Vokal-Swift.xctemplate/ArrayExtensionsTests.swift
@@ -1,0 +1,20 @@
+//
+//  ___FILENAME___
+//  ___PACKAGENAME___
+//
+//  Created by ___FULLUSERNAME___ on ___DATE___.
+//  ___COPYRIGHT___
+//
+
+import XCTest
+
+@testable import ___PACKAGENAME___
+
+class ArrayExtensionsTests: XCTestCase {
+    func testSafeSubscript() {
+        let nums: [Int] = [0, 1, 2]
+        
+        XCTAssertNotNil(nums[safe: nums.startIndex])
+        XCTAssertNil(nums[safe: nums.endIndex])
+    }
+}

--- a/Vokal-Swift.xctemplate/BaseControl.swift
+++ b/Vokal-Swift.xctemplate/BaseControl.swift
@@ -49,5 +49,4 @@ class BaseControl: UIControl, CommonInitializedView {
         super.prepareForInterfaceBuilder()
         self.commonInit()
     }
-
 }

--- a/Vokal-Swift.xctemplate/BaseView.swift
+++ b/Vokal-Swift.xctemplate/BaseView.swift
@@ -49,5 +49,4 @@ class BaseView: UIView, CommonInitializedView {
         super.prepareForInterfaceBuilder()
         self.commonInit()
     }
-
 }

--- a/Vokal-Swift.xctemplate/MainAPIUtility.swift
+++ b/Vokal-Swift.xctemplate/MainAPIUtility.swift
@@ -257,6 +257,5 @@ class MainAPIUtility {
                 failure(NetworkError.otherError(error: error))
             }
         }
-        
     }
 }

--- a/Vokal-Swift.xctemplate/ResetPasswordAPI.swift
+++ b/Vokal-Swift.xctemplate/ResetPasswordAPI.swift
@@ -89,7 +89,6 @@ struct ResetPasswordAPI {
                       headers: self.headerDict,
                       params: parameters,
                       success: success,
-                      failure:failure)
+                      failure: failure)
     }
-
 }

--- a/Vokal-Swift.xctemplate/Scripts/R.swift.sh
+++ b/Vokal-Swift.xctemplate/Scripts/R.swift.sh
@@ -5,4 +5,4 @@ if [[ "${CI}" == 'true' && "${TRAVIS}" == 'true' ]]; then
     exit 0
 fi
 
-"$PODS_ROOT/R.swift/rswift" "$SRCROOT"
+"$PODS_ROOT/R.swift/rswift" generate "$SRCROOT"

--- a/Vokal-Swift.xctemplate/TemplateInfo.plist
+++ b/Vokal-Swift.xctemplate/TemplateInfo.plist
@@ -100,6 +100,7 @@
 	<key>Nodes</key>
 	<array>
 		<string>Extensions/ReuseIdentifiable.swift</string>
+		<string>Extensions/ArrayExtensions.swift</string>
 		<string>main.swift</string>
 		<string>../R.generated.swift</string>
 		<string>AppDelegate.swift</string>
@@ -127,7 +128,7 @@
 		<key>../Podfile:swiftbasics</key>
 		<string>    use_frameworks!
 
-    pod &apos;R.swift&apos;, &apos;~&gt; 3.1&apos;
+    pod &apos;R.swift&apos;, &apos;~&gt; 4.0.0&apos;
     pod &apos;SwiftLint&apos;</string>
 		<key>Extensions/ReuseIdentifiable.swift</key>
 		<dict>
@@ -135,6 +136,13 @@
 			<string>Extensions</string>
 			<key>Path</key>
 			<string>ReuseIdentifiable.swift</string>
+		</dict>
+		<key>Extensions/ArrayExtensions.swift</key>
+		<dict>
+			<key>Group</key>
+			<string>Extensions</string>
+			<key>Path</key>
+			<string>ArrayExtensions.swift</string>
 		</dict>
 		<key>View Controllers/ViewController.swift</key>
 		<dict>
@@ -347,7 +355,7 @@
 					<key>Definitions</key>
 					<dict>
 						<key>../Podfile:afpod</key>
-						<string>    pod &apos;Alamofire&apos;, &apos;~&gt; 4.0&apos;</string>
+						<string>    pod &apos;Alamofire&apos;, &apos;~&gt; 4.7&apos;</string>
 						<key>../Podfile:ilghttp</key>
 						<string>    pod &apos;ILGHttpConstants&apos;, &apos;~&gt; 2.0&apos;</string>
 					</dict>
@@ -487,6 +495,13 @@
 							<key>Group</key>
 							<string>MoveToNonUITestTarget</string>
 						</dict>
+						<key>MoveToNonUITestTarget/ArrayExtensionsTests.swift</key>
+						<dict>
+							<key>Path</key>
+							<string>ArrayExtensionsTests.swift</string>
+							<key>Group</key>
+							<string>MoveToNonUITestTarget</string>
+						</dict>
 						<key>MoveToNonUITestTarget/UserAPITests.swift</key>
 						<dict>
 							<key>Path</key>
@@ -516,6 +531,7 @@
 						<string>MoveToNonUITestTarget/TokenStorageHelperTests.swift</string>
 						<string>MoveToNonUITestTarget/UserAPITests.swift</string>
 						<string>MoveToNonUITestTarget/APICompletionTests.swift</string>
+						<string>MoveToNonUITestTarget/ArrayExtensionsTests.swift</string>
 						<string>MoveToNonUITestTarget/VOKMockData</string>
 					</array>
 					<key>Targets</key>

--- a/Vokal-Swift.xctemplate/TestingAppDelegate.swift
+++ b/Vokal-Swift.xctemplate/TestingAppDelegate.swift
@@ -21,7 +21,7 @@ class TestingAppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
     
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
         let testViewController = UIViewController()
         testViewController.view.backgroundColor = UIColor.red.withAlphaComponent(0.5)
         

--- a/Vokal-Swift.xctemplate/UserAPI.swift
+++ b/Vokal-Swift.xctemplate/UserAPI.swift
@@ -15,8 +15,6 @@ struct UserAPI {
     
     // MARK: - User Key Enums
     
-    // MARK: - User Key Enums
-    
     private enum POSTPath: String, APIVersionable {
         case
         Login = "authenticate",


### PR DESCRIPTION
This pr adds a Swift Array extension to `subscript` for safe subscripting (return `nil` when index is out of bounds rather than crash).

Also added various fixes and syntax cleanups.

@vokal/ios-developers review please