### PR TITLE
Fixed R.swift build phase order

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ You can then delete the `MoveToNonUITestTarget` from the filesystem as the test 
 
 ### 4. For Swift Only
 
-- The build phase that runs the [R.swift](https://github.com/mac-cain13/R.swift) script needs to be moved, since it cannot be positioned properly in the template. In the Build Phases for the main target, drag *R.swift Generation Script* up in the list so that it's right above *Compile Sources*
-
 - There are a couple scripts which are included at the base project level which default to generating Objective-C code. In order to generate Swift files for DevsJustWantToHaveFun, you will need to update the scripts to use `swift` instead of `objc` for the `LANGUAGE` option. These scripts can be found in the `[project]/Scripts` folder. 
 
 ### 5. For All Projects

--- a/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
+++ b/Vokal-Cocoa Touch Application Base.xctemplate/TemplateInfo.plist
@@ -433,6 +433,24 @@ end</string>
 			<array>
 				<dict>
 					<key>Class</key>
+					<string>ShellScript</string>
+					<key>Name</key>
+					<string>R.swift Generation Script</string>
+					<key>ShellPath</key>
+					<string>/bin/bash</string>
+					<key>ShellScript</key>
+					<string>&quot;${SRCROOT}/___PACKAGENAME___/Scripts/R.swift.sh&quot;</string>
+					<key>InputFiles</key>
+					<array>
+						<string>$TEMP_DIR/rswift-lastrun</string>
+					</array>
+					<key>OutputFiles</key>
+					<array>
+						<string>$SRCROOT/R.generated.swift</string>
+					</array>
+				</dict>
+				<dict>
+					<key>Class</key>
 					<string>Sources</string>
 				</dict>
 				<dict>

--- a/Vokal-Swift.xctemplate/TemplateInfo.plist
+++ b/Vokal-Swift.xctemplate/TemplateInfo.plist
@@ -68,24 +68,6 @@
 					<key>Class</key>
 					<string>ShellScript</string>
 					<key>Name</key>
-					<string>R.swift Generation Script</string>
-					<key>ShellPath</key>
-					<string>/bin/bash</string>
-					<key>ShellScript</key>
-					<string>&quot;${SRCROOT}/___PACKAGENAME___/Scripts/R.swift.sh&quot;</string>
-					<key>InputFiles</key>
-					<array>
-						<string>$TEMP_DIR/rswift-lastrun</string>
-					</array>
-					<key>OutputFiles</key>
-					<array>
-						<string>$SRCROOT/R.generated.swift</string>
-					</array>
-				</dict>
-				<dict>
-					<key>Class</key>
-					<string>ShellScript</string>
-					<key>Name</key>
 					<string>SwiftLint Run Script</string>
 					<key>ShellPath</key>
 					<string>/bin/bash</string>


### PR DESCRIPTION
### Goals :soccer:
- Fix build error caused by build phase order - [R.swift](https://github.com/mac-cain13/R.swift#cocoapods-recommended) needs to be "**above** the Compile Sources phase and **below** Check Pods Manifest.lock".

### Implementation Details :construction:
- Added R.swift as the first target build phase of the base application template.
- Removed R.swift shell script from swift template build phases.